### PR TITLE
Colab with Ssh writeup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository introduces several methods for users without local GPU resources.
 
-+ [Transform Google Colab to a GPU instance with full SSH access](docs/Colab-instruction.md)
++ [Transform Google Colab to a GPU instance with full SSH access](docs/colab-instructions.md)

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -2,6 +2,7 @@
 
 For users without local GPU resources, Colab is an available solution. It could be transformed into a GPU instance with full SSH access.
 Here is a more detailed [tutorial](https://imadelhanafi.com/posts/google_colal_server/).
+
 The following is a simplified version of the tutorial.
 
 ## Setup sshd

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -41,8 +41,8 @@ ssh root@[tcp_address] -p [port_number]
 
 These experiments are run under the Colab default setting.
 
-+ [PyGaggle: Baselines on MS MARCO Document Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-document.md): It takes about 8 hours to re-rank each half subset.
++ [PyGaggle: Baselines on MS MARCO Document Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-document.md): It takes about 4 hours to re-rank each half subset.
 
 + [PyGaggle: Neural Ranking Baselines on MS MARCO Passage Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-passage.md):
   + Re-Ranking with monoBERT: It takes about 50 mins to re-rank.
-  + Re-Ranking with monoT5: It takes about 70 mins to re-rank.
+  + Re-Ranking with monoT5: It takes about 40 mins to re-rank.

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -35,3 +35,30 @@ The Port number can be found through the Ngrok interface https://dashboard.ngrok
 ```
 ssh root@0.tcp.ngrok.io -p [port_number]
 ```
+
+## Prevent connection dropping out due to inactivity
+
+Ssh connection drops out after several minutes of inactivity. 
+There are two options to fix this problem.
+
++ Server side configuration
+  Please log into the remote server and then open your configuration file.
+  ```
+  vi /etc/ssh/sshd_config
+  ```
+  Modify setting as follows:
+  ```
+  ClientAliveInterval 30
+  ClientAliveCountMax 5
+  ```
+
++ Client side configuration
+  Another option is to enable ServerAliveInterval option on the client’s side.
+  ```
+  $ vi ~/.ssh/ssh_config
+  ```
+  Modify setting as follows:
+  ```
+  ServerAliveInterval 15
+  ServerAliveCountMax 3
+  ```

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -2,9 +2,7 @@
 
 For users without local GPU resources, Colab is an available solution. It could be transformed into a GPU instance with full SSH access.
 
-Here is a more detailed [tutorial](https://imadelhanafi.com/posts/google_colal_server/).
-
-The following is a simplified version of the tutorial.
+This document refers to this [tutorial](https://imadelhanafi.com/posts/google_colal_server/).
 
 ## Setup sshd
 First of all, create a Colab notebook using your Google account and use the GPU runtime mode.
@@ -38,3 +36,13 @@ The TCP address and port number can be found through the Ngrok interface https:/
 ```
 ssh root@[tcp_address] -p [port_number]
 ```
+
+## Time consumption on experiments
+
+These experiments are run under the Colab default setting.
+
++ [PyGaggle: Baselines on MS MARCO Document Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-document.md): It takes about 8 hours to re-rank each half subset.
+
++ [PyGaggle: Neural Ranking Baselines on MS MARCO Passage Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-passage.md):
+  + Re-Ranking with monoBERT: It takes about 50 mins to re-rank.
+  + Re-Ranking with monoT5: It takes about 70 mins to re-rank.

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -39,7 +39,7 @@ ssh root@[tcp_address] -p [port_number]
 
 ## Time consumption on experiments
 
-These experiments are run under the Colab default setting.
+These experiments are run under the Colab default setting(T4).
 
 + [PyGaggle: Baselines on MS MARCO Document Retrieval](https://github.com/castorini/pygaggle/blob/master/docs/experiments-msmarco-document.md): It takes about 4 hours to re-rank each half subset.
 

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -1,6 +1,7 @@
 # Colab as a GPU instance with full SSH access
 
 For users without local GPU resources, Colab is an available solution. It could be transformed into a GPU instance with full SSH access.
+
 Here is a more detailed [tutorial](https://imadelhanafi.com/posts/google_colal_server/).
 
 The following is a simplified version of the tutorial.

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -1,6 +1,8 @@
 # Colab as a GPU instance with full SSH access
 
 For users without local GPU resources, Colab is an available solution. It could be transformed into a GPU instance with full SSH access.
+Here is a more detailed [tutorial](https://imadelhanafi.com/posts/google_colal_server/).
+The following is a simplified version of the tutorial.
 
 ## Setup sshd
 First of all, create a Colab notebook using your Google account and use the GPU runtime mode.

--- a/docs/colab-instructions.md
+++ b/docs/colab-instructions.md
@@ -16,6 +16,8 @@ Let's setup and run `sshd`.
 ! mkdir -p /var/run/sshd
 ! echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
 ! echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+! echo "ClientAliveInterval 30" >> /etc/ssh/sshd_config
+! echo "ClientAliveCountMax 5" >> /etc/ssh/sshd_config
 get_ipython().system_raw('/usr/sbin/sshd -D &')
 ```
 
@@ -32,34 +34,7 @@ get_ipython().system_raw('./ngrok authtoken $authtoken && ./ngrok tcp 22 &')
 
 ## Access your server
 Now, You can access your server through `ssh` command in your local machine.
-The Port number can be found through the Ngrok interface https://dashboard.ngrok.com/status.
+The TCP address and port number can be found through the Ngrok interface https://dashboard.ngrok.com/status.
 ```
-ssh root@0.tcp.ngrok.io -p [port_number]
+ssh root@[tcp_address] -p [port_number]
 ```
-
-## Prevent connection dropping out due to inactivity
-
-Ssh connection drops out after several minutes of inactivity. 
-There are two options to fix this problem.
-
-+ Server side configuration
-  Please log into the remote server and then open your configuration file.
-  ```
-  vi /etc/ssh/sshd_config
-  ```
-  Modify setting as follows:
-  ```
-  ClientAliveInterval 30
-  ClientAliveCountMax 5
-  ```
-
-+ Client side configuration
-  Another option is to enable ServerAliveInterval option on the client’s side.
-  ```
-  $ vi ~/.ssh/ssh_config
-  ```
-  Modify setting as follows:
-  ```
-  ServerAliveInterval 15
-  ServerAliveCountMax 3
-  ```


### PR DESCRIPTION
Rename the document to the existing conventions and add the original link.
Add tips to solve the timeout problem.
This document should contain all the necessary code to run Colab through ssh.