### PR TITLE
Add interactive jobs' time limit

### DIFF
--- a/docs/cc-guide.md
+++ b/docs/cc-guide.md
@@ -34,6 +34,8 @@ Always keep in mind that SLURM deals with a lot of requests, so (1) your jobs do
 
 There are (at least) 2 ways to submit a job: interactive and non-interactive.
 
+If your job's maximum time is longer than 24 hours, please submit that job in a non-interactive way because the time limit of interactive jobs is 24 hours.
+
 * Interactive: you get a shell on the computing node and run jobs as usual. Useful when you are running experiments for the first time and need to debug here and there. Command:
 
   `srun --mem=64G --cpus-per-task=2 --time=24:0:0 --gres=gpu:v100l:2 --pty zsh`


### PR DESCRIPTION
Because replication of full dev set is longer than 24 hours, you have to send non-interactive jobs.
Add a small reminder.